### PR TITLE
Allow setting the re2 version more easily in the monorepo

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
         {semver, "0.0.1", {pkg, semver_erl}},
         {uuid, "1.7.4", {pkg, uuid_erl}},
         {pooler, "1.5.3"},
-        {re2, {git, "git://github.com/dukesoferl/re2.git", {tag, "v1.9.4"}}}
+        {re2, {git, "git://github.com/dukesoferl/re2.git"}}
 ]}.


### PR DESCRIPTION
Will be good to update re2 because they fix the bug which prevents it compiling on macos, so we can specify what version of re2 to use in our monorepo's lockfile